### PR TITLE
defense systems

### DIFF
--- a/docs/defense.rst
+++ b/docs/defense.rst
@@ -1,0 +1,12 @@
+Defense systems
+=========================
+
+The results of running DefenseFinder v1.3.0 on all Enterobacterales species with >400 samples from release 0.2 plus incremental release 2024-08 are available on OSF in the `DefenseFinder component <https://osf.io/hpgac/overview>`_. This includes 27 species and 1,166,956 samples. 
+
+Note that this analysis is all with DefenseFinder `v1.3.0 <https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0>`_ using the profiles from defense-finder-models v1.3.0 and CasFinder v3.1.0. This means that defense systems added to DefenseFinder after July 2024 will not be present in the results. the time of writing (February 2026) the latest release of DefenseFinder is v2.0.1  
+
+We have shared a single results file which is the concatenated output of the `systems.tsv` file from all individual DefenseFinder runs. The status file indicates which samples we ran the analysis on with ``PASS`` if the run completed successfully. There are n=653 samples where no defense system was detected in the assembly, so these samples are absent from the results file but coded as ``PASS`` in the status file. 
+
+**Important:** Note that this analysis is all with DefenseFinder `v1.3.0 <https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0>`_ using the profiles from CasFinder v3.1.0 and defense-finder-models v1.3.0, the latter of which includes 151 defense systems (and 16 anti-defense systems). This means that newer defense systems added to DefenseFinder after July 2024 will not be present in the results. For context, as of February 2026 the latest release of DefenseFinder is v2.0.1 and the latest models version (v2.0.2) contains 262 defense systems. 
+
+More details on the analysis are available on the AllTheBacteria github `here <https://github.com/AllTheBacteria/AllTheBacteria/tree/main/reproducibility/All-samples/defense-systems>`_. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ https://github.com/AllTheBacteria/AllTheBacteria/issues
    species_id
    annotation
    amr
+   defense
    bgcs
    typing
    archaea

--- a/reproducibility/All-samples/defense-systems/README.md
+++ b/reproducibility/All-samples/defense-systems/README.md
@@ -1,0 +1,50 @@
+# Defense systems
+
+Contributors: Liam Shaw, Rachel Wheatley, Robert A. Petit III
+
+The initial aim of this analysis was to investigate defense systems within Enterobacterales. We ran [DefenseFinder](https://github.com/mdmparis/defense-finder) v1.3.0 on Enterobacterales species with >400 samples (27 species, n=1,166,956 samples) within AllTheBacteria release 0.2 plus incremental release 2024-08. The results are available on OSF [here](https://osf.io/hpgac/overview). 
+
+By default, DefenseFinder produces three main outputs: `*genes.tsv`, `*hmmer.tsv` and `*systems.tsv`. We have shared a single file containing the concatenated results of `*systems.tsv`. This file contains results from 1,166,303 samples with a total of 9,936,568 defense systems (mean 8.5 systems detected per sample). 
+
+## Software versions
+
+DefenseFinder relies on 'models', consisting of HMMs for detecting hits then definitions/rules for calling systems as present. We used:
+
+* DefenseFinder [v1.3.0](https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0) (release link)
+* CasFinder [v3.1.0](https://github.com/macsy-models/CasFinder/archive/refs/tags/3.1.0.tar.gz) (download link)
+* defense-finder-models [v1.3.0](https://github.com/mdmparis/defense-finder-models/releases/download/1.3.0/defense-finder-models-v1.3.0.tar.gz) (download link)
+
+With these versions, in principle 151 defense systems and 16 anti-defense systems can be detected. Newer defense systems that were added to DefenseFinder models after July 2024 will not be present in the results. For context, as of February 2026 the latest release of DefenseFinder is v2.0.1 and the latest models version (v2.0.2) contains 262 defense systems. 
+
+
+## Workflow
+
+The basic command for each sample was identical:
+
+```
+defense-finder run ${SAMPLE}.fa
+```
+
+We split this analysis between the three of us on three separate computing clusters, and each of us did it slightly differently. For each species, we downloaded all assemblies matching that species name from AllTheBacteria using `atb-downloader` from [Bactopia](https://github.com/bactopia/bactopia/tree/dev):
+
+```
+bactopia atb-downloader --query <SPECIES>
+```
+
+For an example slurm array job to run DefenseFinder on a single sample at a time, assuming you have a list of `samples.txt` that you have not already downloaded, see `array-job.sh`. For an example of how to download all samples for a species and then run DefenseFinder sequentially in a loop, see `sequential-job.sh`. Depending on the computing resources available to you, batching samples together in array jobs may make for better efficiency - bear this in mind for running large numbers of samples.
+
+One of us (Liam) combined all our results together into a single tsv. See `checking_data.py` for some light checks made like checking for samples with/without defense systems against the overall species calls, and the construction of the status file. 
+
+## Assembly quality
+
+DefenseFinder was developed for complete genomes. Obviously this is not the case for AllTheBacteria assemblies - be careful!
+
+In particular, our list of samples also includes samples assessed as low-quality after running the `assembly-stats` pipeline (those results are available on OSF [here](https://osf.io/h7wzy/files/7t9qd)). We found that 653 samples did not have any defense systems detected, and we verified this with a rerun of DefenseFinder for these samples. The majority of these were low-quality (354/653, 54.2%) (HQ=F in OSF species calls), two orders of magnitude more than the low-quality proportion in samples where at least one system was detected (n=6909, 0.59%), highlighting that under-detection is likely a greater problem for more fragmented assemblies. However, we also noticed that low-quality samples could have suspiciously high numbers of unique systems: the most defense systems observed in a high-quality sample was 33, but some low-quality samples had higher numbers (up to 57). 
+
+## Acknowledgements
+
+Many thanks to the authors of DefenseFinder who made this analysis possible by making their tool openly available! We gratefully acknowledge and cite the publications this analysis rests on:
+
+* "Systematic and quantitative view of the antiviral arsenal of prokaryotes" Nature Communications (2022) Tesson et al. [link](https://doi.org/10.1038/s41467-022-30269-9)
+* "MacSyFinder v2: Improved modelling and search engine to identify molecular systems in genomes" Peer Community Journal (2023) Néron et al. [link](https://doi.org/10.24072/pcjournal.250)
+* "CRISPRCasFinder, an update of CRISRFinder, includes a portable version, enhanced performance and integrates search for Cas proteins" Nucleic Acids Research (2018) Couvin et al. [link](https://doi.org/10.1093/nar/gky425)

--- a/reproducibility/All-samples/defense-systems/array-job.sh
+++ b/reproducibility/All-samples/defense-systems/array-job.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#SBATCH --job-name=defensefinder
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=4
+#SBATCH --time=00:20:00 # in practice most run <10min
+#SBATCH --mem=200M # in practice many run <100M
+#SBATCH --array=1
+
+# Setting params to make sure DefenseFinder sees availability of threads (unclear if this really matters)
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+export MKL_NUM_THREADS=$SLURM_CPUS_PER_TASK
+export OPENBLAS_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+# Get name of sample from sample list
+name=$(sed -n "${SLURM_ARRAY_TASK_ID}p" samples.txt)
+
+# Download the assembly
+wget https://allthebacteria-assemblies.s3.eu-west-2.amazonaws.com/"$name".fa.gz
+gunzip "$name".fa.gz
+
+# Initiate conda environment with DefenseFinder
+. ~/initMamba.sh
+conda activate defensefinder-1.3.0
+
+# Temporary directory (defensefinder will complain if you set off simultaneous array jobs with same output dir)
+mkdir -p tmp_${SLURM_ARRAY_TASK_ID}
+# Run Defense-Finder
+defense-finder run SAMN21988166.fa --workers ${SLURM_CPUS_PER_TASK} -o tmp_${SLURM_ARRAY_TASK_ID}

--- a/reproducibility/All-samples/defense-systems/checking_data.py
+++ b/reproducibility/All-samples/defense-systems/checking_data.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import re
+import numpy as np
+
+
+species_calls = pd.read_csv("~/Downloads/species_calls.tsv", sep="\t")
+
+defense_systems = pd.read_csv("/Users/Liam/Downloads/combined-ATB-defense-finder/new/combined_all_data_6_feb.tsv", sep="\t")
+# Add a sample column
+defense_systems["Sample"] = defense_systems["sys_id"].str.replace(r"\..*$", "", regex=True)
+cols = ["Sample"] + [c for c in defense_systems.columns if c != "Sample"]
+defense_systems = defense_systems[cols]
+
+samples_with_systems = set(defense_systems["Sample"])
+
+def samples_for_species(species_name):
+	'''gets all samples for a given species'''
+	return list(species_calls[species_calls['Species']==species_name]['Sample'])
+
+
+# List of species 
+species_names = [x.strip() for x in open("/Users/Liam/Downloads/combined-ATB-defense-finder/new/species-names-formatted.txt", "r").readlines()]
+samples_without_systems = set()
+combined_species_samples = set()
+for species in species_names:
+	# For each species, we fetch all the sample calls
+	species_samples = set(samples_for_species(species))
+	combined_species_samples = combined_species_samples.union(species_samples)
+	# We look at those that apparently don't have any defense systems
+	species_samples_without_systems = species_samples - samples_with_systems
+	samples_without_systems = samples_without_systems.union(species_samples_without_systems)
+
+# Write these to a file so we can rerun them to verify
+with open("/Users/Liam/Downloads/combined-ATB-defense-finder/new/rerun-samples.txt", "w") as f:
+	for sample in samples_without_systems:
+		f.write("%s\n" % sample)
+
+# Write the combined data output to a single file
+defense_systems.to_csv("/Users/Liam/Downloads/combined-ATB-defense-finder/new/combined_all_data_6_feb_for_upload.tsv", sep="\t", index=False)
+
+# Assess the low/high-quality for samples with/without defense systems detected
+species_calls[species_calls["Sample"].isin(samples_with_systems)]["HQ"].value_counts()
+species_calls[species_calls["Sample"].isin(samples_without_systems)]["HQ"].value_counts()
+
+# Make status file for our analysis
+species_calls["Status"] = np.where(
+    species_calls["Sample"].isin(combined_species_samples),
+    "PASS",
+    "NOT DONE"
+)
+cols = ["Sample", "Status"]
+species_calls[cols].to_csv("/Users/Liam/Downloads/combined-ATB-defense-finder/new/defense_finder_status_20260206.tsv", sep='\t', index=False)
+
+
+## Assembly statistics
+# Make a summary table
+system_counts = defense_systems.groupby("Sample")["subtype"].nunique() 
+# assembly stats
+assembly_stats = pd.read_csv("~/Downloads/assembly-stats.tsv", sep="\t")
+
+combined = assembly_stats.merge(
+	summary,
+	left_index=True,
+	right_on="Sample",
+	how="inner")
+# Add species, quality information
+combined_2 = combined.merge(
+	species_calls,
+	left_index=True,
+	right_on="Sample",
+	how="inner"
+	)

--- a/reproducibility/All-samples/defense-systems/sequential-job.sh
+++ b/reproducibility/All-samples/defense-systems/sequential-job.sh
@@ -1,0 +1,12 @@
+# Activate bactopia-dev environment: see https://github.com/bactopia/bactopia/tree/dev
+conda activate bactopia-dev
+# Download all samples from AllTheBacteria that match "species name"
+bactopia atb-downloader -q "species name"
+conda deactivate
+# Gunzip the files
+gunzip *.fa.gz
+# Activate defense-finder environment
+conda activate defense-finder-env
+# Run on all downloaded samples with a loop
+for i in *.fa; do defense-finder run $i ; done &
+


### PR DESCRIPTION
Adding files for DefenseFinder analysis on Enterobacterales species:

* `docs/defense.rst` - basic instructions for using data and link to OSF project (`defense` also added to `index.rst` on a line that seemed sensible)
* `reproducibility/All-samples/defense-systems` - new folder containing `README.md` with reproducibility info and example scripts

N.B. doesn't include any rebuild of documentation